### PR TITLE
Add support for passing noload to url

### DIFF
--- a/src/static/js/binder/core/dynamic_frame.js
+++ b/src/static/js/binder/core/dynamic_frame.js
@@ -253,6 +253,10 @@ class DynamicFrame extends Controller {
     endpoint() {
         let url = this.args.url;
 
+        if (url === "noload") {
+            return;
+        }
+
         if (!this.args.url) {
             console.error(`${this.tag}: No :url attribute specified`);
             return;


### PR DESCRIPTION
Pass `"noload"` as the url argument to have the dynamic frame not load anything.  This will be used to not load the dynamic frame on window load, but instead load it manually with JS when a button is clicked.