### PR TITLE
Add breakout redirect support

### DIFF
--- a/src/static/js/binder/core/dynamic_frame.js
+++ b/src/static/js/binder/core/dynamic_frame.js
@@ -159,6 +159,13 @@ class DynamicFrame extends Controller {
                     return;
                 }
 
+                // Special header for redirecting the outer page
+                // Useful for errors or session timeouts
+                if (response.headers.get("X-Dynamic-Frame-Page-Redirect")) {
+                    window.location.href = response.headers.get("X-Dynamic-Frame-Page-Redirect");
+                    return;
+                }
+
                 let text = await response.text();
                 this.updateContent(text);
             } catch (err) {


### PR DESCRIPTION
It can sometimes be useful to return a redirect to a dynamic frame that should redirect the entire page and not just within the frame, for example when a login session expires or when handling errors.

This is currently possible by return a javascript redirect to the frame but that only works if the frame has `:execute-scripts` enabled.

This change adds support for returning a redirect via the `X-Dynamic-Frame-Page-Redirect` header.

Example usage with Flask:
```python3
@app.errorhandler(SessionExpired)
def handle_session_expired(e):
    from flask import make_response
    from flask import session as flask_session

    response = make_response("Session expired")
    flask_session.pop("login_session_key", None)
    response.headers["X-Dynamic-Frame-Page-Redirect"] = "/login"
    return response
```