### PR TITLE
Emit an event when updating frame from cache

### DIFF
--- a/src/static/js/binder/core/dynamic_frame.js
+++ b/src/static/js/binder/core/dynamic_frame.js
@@ -546,6 +546,9 @@ class DynamicFrameRouter extends Controller {
         if (href in this.cache) {
             this.target.replaceChildren(...this.cache[href]);
             this.target.args.url = href;
+            this.target.emit("dynamic-frame:updated", {
+                fromCache: true,
+            });
         } else {
             await this.target.loadUrl(href);
         }


### PR DESCRIPTION
When updating a frame from cache via `DynamicFrameRouter`  emit the `dynamic-frame:updated` event from the updated frame.

The second argument to `emit` is the `detail` in the event.
```javascript
window.addEventListener("dynamic-frame:updated", e => {
	if (e.details.fromCache) {
		// Special cached update logic
	} else {
		// Regular `fetch` update logic
	}
}
```